### PR TITLE
Feat/support generics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: refs|docs/
 repos:
   - repo: https://github.com/JanEricNitschke/pymend
-    rev: "v1.0.11"
+    rev: "v1.0.12"
     hooks:
       - id: pymend
         language: python

--- a/pymend/const.py
+++ b/pymend/const.py
@@ -9,3 +9,11 @@ DEFAULT_DESCRIPTION = "_description_"
 DEFAULT_TYPE = "_type_"
 DEFAULT_SUMMARY = "_summary_."
 DEFAULT_EXCEPTION = "__UnknownError__"
+
+ARG_TYPE_SET = "Parameter had type despite `force-arg-types=False` being set."
+RETURN_TYPE_SET = (
+    "Return type was specified despite `force-return-type=False` being set."
+)
+ATTRIBUTE_TYPE_SET = (
+    "Attribute had type despite `force-attribute-types=False` being set."
+)

--- a/pymend/docstring_parser/common.py
+++ b/pymend/docstring_parser/common.py
@@ -13,6 +13,7 @@ PARAM_KEYWORDS = {
     "arg",
     "argument",
     "attribute",
+    "generics",
     "key",
     "keyword",
 }
@@ -184,6 +185,22 @@ class Docstring:
         self.meta: list[DocstringMeta] = []
         self.style: Optional[DocstringStyle] = style
         self.section_titles: KeyReturnDict[str, str] = section_titles or KeyReturnDict()
+
+    def __bool__(self) -> bool:
+        """Return True if the docstring has any content.
+
+        Returns
+        -------
+        bool
+            True if the docstring has any content.
+        """
+        return any(
+            (
+                self.short_description,
+                self.long_description,
+                self.meta,
+            )
+        )
 
     @property
     def params(self) -> list[DocstringParam]:

--- a/pymend/docstring_parser/google.py
+++ b/pymend/docstring_parser/google.py
@@ -79,6 +79,7 @@ DEFAULT_SECTIONS = [
     Section("Exceptions", "raises", SectionType.MULTIPLE),
     Section("Except", "raises", SectionType.MULTIPLE),
     Section("Attributes", "attribute", SectionType.MULTIPLE),
+    Section("Generics", "generics", SectionType.MULTIPLE),
     Section("Example", "examples", SectionType.SINGULAR),
     Section("Examples", "examples", SectionType.SINGULAR),
     Section("Returns", "returns", SectionType.SINGULAR_OR_MULTIPLE),
@@ -638,6 +639,11 @@ def compose(  # noqa: PLR0915
     )
 
     process_sect(
+        "Generics",
+        [p for p in docstring.params or [] if p.args[0] == "generics"],
+    )
+
+    process_sect(
         "Returns",
         docstring.many_returns,
     )
@@ -659,7 +665,7 @@ def compose(  # noqa: PLR0915
             continue  # Already handled
         parts.append(f'{titles[meta.args[0].replace("_", "").title()]}:')
         if meta.description:
-            lines = [indent + line for line in meta.description.splitlines()]
+            lines = [(indent + line).rstrip() for line in meta.description.splitlines()]
             parts.append("\n".join(lines))
         parts.append("")
 

--- a/pymend/pymend.py
+++ b/pymend/pymend.py
@@ -285,6 +285,8 @@ class PyComment:
             The properly indented docstring, wrapped in triple quotes
             and preceded by the desired modifier.
         """
+        if not docstring:
+            return ""
         split = f"{modifier}{quotes}{docstring}".splitlines()
         # One line docstring get the quotes on the same line
         if len(split) > 1:

--- a/pymend/pymendapp.py
+++ b/pymend/pymendapp.py
@@ -331,6 +331,15 @@ def read_pyproject_toml(
     ),
 )
 @click.option(
+    "--force-docstrings/--unforce-docstrings",
+    is_flag=True,
+    default=True,
+    help=(
+        "Whether to force a docstring even if there is none present."
+        " If set to `False`, will only fix existing docstrings."
+    ),
+)
+@click.option(
     "--force-params/--unforce-params",
     type=bool,
     is_flag=True,
@@ -355,9 +364,9 @@ def read_pyproject_toml(
     type=int,
     default=0,
     help="Minimum number statements in the function body"
-    " to actually enforce parameters."
+    " to actually enforce parameters and returns."
     " If less than the specified numbers of statements are"
-    " detected then a parameters section is only build for new docstrings."
+    " detected then a parameters and return section is only build for new docstrings."
     " No new sections are created for existing docstrings and existing sections"
     " are not extended. Only has an effect with"
     " `--force-params` or `--force-return` set to true.",
@@ -389,7 +398,7 @@ def read_pyproject_toml(
     default=False,
     help="Whether to force a methods section for classes even if"
     " there is already an existing docstring."
-    " If set it will force on entry in the section per method found."
+    " If set it will force one entry in the section per method found."
     " If only some methods are desired to be specified then this should be left off.",
 )
 @click.option(
@@ -460,6 +469,12 @@ def read_pyproject_toml(
     help="Whether to force the arguments section to specify type information.",
 )
 @click.option(
+    "--force-attribute-types/--unforce-attribute-types",
+    is_flag=True,
+    default=True,
+    help="Whether to force the attributes section to specify type information.",
+)
+@click.option(
     "--indent", type=int, default=4, help="Number of characters used for indentation."
 )
 @click.option(
@@ -520,6 +535,7 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
     check: bool,
     exclude: Optional[Pattern[str]],
     extend_exclude: Optional[Pattern[str]],
+    force_docstrings: bool,
     force_params: bool,
     force_params_min_n_params: bool,
     force_meta_min_func_length: bool,
@@ -535,6 +551,7 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
     force_defaults: bool,
     force_return_type: bool,
     force_arg_types: bool,
+    force_attribute_types: bool,
     indent: int,
     quiet: bool,
     verbose: bool,
@@ -563,6 +580,7 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
 
     report = Report(check=check, diff=not write, quiet=quiet, verbose=verbose)
     fixer_settings = FixerSettings(
+        force_docstrings=force_docstrings,
         force_params=force_params,
         force_return=force_return,
         force_raises=force_raises,
@@ -578,6 +596,7 @@ def main(  # pylint: disable=too-many-arguments, too-many-locals  # noqa: PLR091
         force_defaults=force_defaults,
         force_return_type=force_return_type,
         force_arg_types=force_arg_types,
+        force_attribute_types=force_attribute_types,
         indent=indent,
     )
 

--- a/pymend/types.py
+++ b/pymend/types.py
@@ -252,7 +252,7 @@ class DocstringInfo:
                     f" {returned.type_name} |"
                     f" {returned.description}`."
                 )
-            elif not settings.force_return_type:
+            elif returned.type_name and not settings.force_return_type:
                 self.issues.append(RETURN_TYPE_SET)
             returned.type_name = (
                 (returned.type_name or DEFAULT_TYPE)


### PR DESCRIPTION
- Added support for generics in google docstrings.
- Indentation is now handled correctly on empty lines in google examples
- Allow only fixing of docstrings without generation of new ones
- Ignore `cls` in functions decorated with `classmethod`
- Various precendence fixes

